### PR TITLE
remove ox_lib enforcement

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1,29 +1,26 @@
--- variables
-local config = require 'config'
-
 -- functions --
 local function OpenUI()
-    SendNUIMessage({ action = 'SHOW_UI' })
-    SetNuiFocus(true, true)
+  SendNUIMessage({ action = 'SHOW_UI' })
+  SetNuiFocus(true, true)
 end
 
 -- NUI Callbacks --
 RegisterNUICallback('CLOSE_UI', function()
-    SetNuiFocus(false, false)
+  SetNuiFocus(false, false)
 end)
 
 -- TEST CALLBACK --
 RegisterNUICallback('TEST_CB', function(data, cb)
-    print(json.encode(data), type(data)) -- received data
+  print(json.encode(data), type(data))   -- received data
 
-    cb(data) -- return data
+  cb(data)                               -- return data
 end)
 
 -- Commands --
 if config.command then
-    RegisterCommand(config.command, OpenUI)
+  RegisterCommand(config.command, OpenUI)
 
-    if config.keybind then
-        RegisterKeyMapping(config.command, 'Guidebook', 'keyboard', config.keybind)
-    end
+  if config.keybind then
+    RegisterKeyMapping(config.command, 'Guidebook', 'keyboard', config.keybind)
+  end
 end

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
-return {
-    -- list of control keys https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
+config = {
+  -- list of control keys https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
 
-    command = 'terminal', -- name of command
-    keybind = false, -- control key or false to disable it
+  command = 'terminal', -- name of command
+  keybind = false,      -- control key or false to disable it
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,4 +1,4 @@
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'
 lua54 'yes'
 
@@ -6,21 +6,14 @@ author 'sheen'
 description 'Hacking Terminal'
 version '1.0'
 
-shared_scripts {
-    '@ox_lib/init.lua',
-}
 client_scripts {
-    'client/client.lua',
+  'config.lua',
+  'client/client.lua',
 }
 
 ui_page 'html/index.html'
-files { 
-    'config.lua',
-    'html/index.html', 
-    'html/script.js',
-    'html/styles.css',
-}
-
-escrow_ignore {
-    '**.lua',
+files {
+  'html/index.html',
+  'html/script.js',
+  'html/styles.css',
 }


### PR DESCRIPTION
There is literally 0 need to force people to require ox_lib on base, this is a simple script that has no ties in to the ox utility in any way shape or form, if you didn't know how to make a global config for the script, this PR will now also show you how to do that.

Literally no need for useless things.

